### PR TITLE
Adding amp resize message

### DIFF
--- a/src/iframeMessenger.js
+++ b/src/iframeMessenger.js
@@ -138,8 +138,15 @@
                 type:'set-height',
                 value: height
             };
+            // For AMP pages iframes must send a specific message for resizing
+            var ampMessage = {
+                sentinel: 'amp',
+                type: 'embed-size',
+                height: height
+            };
 
             _postMessage(message);
+            _postMessage(ampMessage);
         }
 
         /**


### PR DESCRIPTION
Hello! I am currently working on implementing [AMP](https://www.ampproject.org/) on [guardian/frontend](https://github.com/guardian/frontend)

The step I am on now is making sure that embedded interactives will render. For this to work I need to make sure I can send the correct resize message from the child to the parent. We already send one similar, but unfortunately the [spec](https://github.com/ampproject/amphtml/blob/38fbbdd824ed1887c9258b06627fcc394d6310dd/extensions/amp-iframe/amp-iframe.md#iframe-resizing) calls for a very particular format.
