### PR TITLE
[acquisitions] acquisition link enrichment functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,21 @@ Sample of returned position data object:
 }
 ```
 
+#### .enrichAcquisitionLinks()
+_Guardian specific._ Adds the field-value pair `acquisitionData=<encode JSON>` to all links with class 
+`"js-acquisition-link"`. Typical usage:
+```Javascript
+<script src="https://interactive.guim.co.uk/libs/iframe-messenger/iframeMessenger.js"></script>
+<script>
+    iframeMessenger.enrichAcquisitionLinks({
+        componentId: 'us_campain_epic',
+        componentType: 'ACQUISITIONS_EPIC',
+        source: 'GUARDIAN_WEB',
+        campaignCode: 'us_campaign'
+    })
+</script>
+```
+
 ## Similar projects
  - **easyXDM**: De facto standard https://github.com/oyvindkinsey/easyXDM
  - **jquery-iframe-auto-height**: Good cross-browser support https://github.com/house9/jquery-iframe-auto-height
@@ -116,6 +131,9 @@ Sample of returned position data object:
 
 
 ## Changelog
+0.2.8
+- Added .enrichAcquisitionLinks(object)
+
 0.2.7
 - Added support for AdobeEdge content
 - New method for wrapping content using ::before and ::after CSS

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ _Guardian specific._ Adds the field-value pair `acquisitionData=<encode JSON>` t
 <script src="https://interactive.guim.co.uk/libs/iframe-messenger/iframeMessenger.js"></script>
 <script>
     iframeMessenger.enrichAcquisitionLinks({
-        componentId: 'us_campain_epic',
+        componentId: 'us_campaign_epic',
         componentType: 'ACQUISITIONS_EPIC',
         source: 'GUARDIAN_WEB',
         campaignCode: 'us_campaign'

--- a/src/iframeMessenger.js
+++ b/src/iframeMessenger.js
@@ -1,7 +1,7 @@
 /**
  * iframe-messenger
  *
- * version: 0.2.7
+ * version: 0.2.8
  * source: https://github.com/GuardianInteractive/iframe-messenger
  *
  */

--- a/src/iframeMessenger.js
+++ b/src/iframeMessenger.js
@@ -441,7 +441,9 @@
             _postMessage(message, function(data) {
                 var referrerData = data.referrerData;
                 if (referrerData && data.type === message.type) {
-                    _addAcquisitionDataToLinks(Object.assign({}, acquisitionData, referrerData))
+                    acquisitionData.referrerUrl = referrerData.referrerUrl;
+                    acquisitionData.referrerPageviewId = referrerData.referrerPageviewId;
+                    _addAcquisitionDataToLinks(acquisitionData);
                 }
             });
         }

--- a/src/iframeMessenger.js
+++ b/src/iframeMessenger.js
@@ -439,15 +439,15 @@
 
         function _buildAcquisitionData(acquisitionData, referrerData) {
             if (acquisitionData && referrerData) {
-                var out = {};
-                out.componentId = acquisitionData.componentId;
-                out.componentType = acquisitionData.componentType;
-                out.source = acquisitionData.source;
-                out.abTest = acquisitionData.abTest;
-                out.campaignCode = acquisitionData.campaignCode;
-                out.referrerPageviewId = referrerData.referrerPageviewId;
-                out.referrerUrl = referrerData.referrerUrl;
-                return out;
+                return {
+                    componentId: acquisitionData.componentId,
+                    componentType: acquisitionData.componentType,
+                    source: acquisitionData.source,
+                    abTest: acquisitionData.abTest,
+                    campaignCode: acquisitionData.campaignCode,
+                    referrerPageviewId: referrerData.referrerPageviewId,
+                    referrerUrl: referrerData.referrerUrl
+                }
             }
             return null;
         }

--- a/src/iframeMessenger.js
+++ b/src/iframeMessenger.js
@@ -429,11 +429,7 @@
             for (var i = 0; i < links.length; i++) {
                 var href = link.getAttribute('href');
                 if (href) {
-                    if (href.indexOf('?') === -1) {
-                        href += '?';
-                    } else {
-                        href += '&';
-                    }
+                    href += href.indexOf('?') === -1 ? '?' : '&';
                     href += 'acquisitionData=';
                     href += json;
                     link.setAttribute('href', href);                    

--- a/src/iframeMessenger.js
+++ b/src/iframeMessenger.js
@@ -429,14 +429,8 @@
             for (var i = 0; i < links.length; i++) {
                 var href = link.attr('href');
                 if (href) {
-                    var url;
-                    try {
-                        url = new URL(href);
-                    } catch (e) {
-                        return;
-                    }
-                    url.searchParams.set('acquisitionData', json);
-                    link.attr('href', url.toString())
+                    href = `${href}${href.includes('?') ? '&' : '?'}${json}`;
+                    link.attr('href', href);                    
                 }
             }
         }

--- a/src/iframeMessenger.js
+++ b/src/iframeMessenger.js
@@ -436,11 +436,7 @@
         }
 
         function _buildAcquisitionData(acquisitionData, referrerData) {
-            if (acquisitionData && 
-                typeof acquisitionData === 'object' && 
-                referrerData &&
-                typeof referrerData === 'object') 
-            {
+            if (acquisitionData && referrerData) {
                 var out = {};
                 out.componentId = acquisitionData.componentId;
                 out.componentType = acquisitionData.componentType;
@@ -449,7 +445,7 @@
                 out.campaignCode = acquisitionData.campaignCode;
                 out.referrerPageviewId = referrerData.referrerPageviewId;
                 out.referrerUrl = referrerData.referrerUrl;
-                return out
+                return out;
             }
             return null;
         }

--- a/src/iframeMessenger.js
+++ b/src/iframeMessenger.js
@@ -435,15 +435,35 @@
             }
         }
 
+        function _buildAcquisitionData(acquisitionData, referrerData) {
+            if (acquisitionData && 
+                typeof acquisitionData === 'object' && 
+                referrerData &&
+                typeof referrerData === 'object') 
+            {
+                var out = {};
+                out.componentId = acquisitionData.componentId;
+                out.componentType = acquisitionData.componentType;
+                out.source = acquisitionData.source;
+                out.abTest = acquisitionData.abTest;
+                out.campaignCode = acquisitionData.campaignCode;
+                out.referrerPageviewId = referrerData.referrerPageviewId;
+                out.referrerUrl = referrerData.referrerUrl;
+                return out
+            }
+            return null;
+        }
+
         function _enrichAcquisitionLinks(acquisitionData) {
             _addAcquisitionDataToLinks(acquisitionData);
             var message = { type: 'enrich-acquisition-links' };
             _postMessage(message, function(data) {
                 var referrerData = data.referrerData;
                 if (referrerData && data.type === message.type) {
-                    acquisitionData.referrerUrl = referrerData.referrerUrl;
-                    acquisitionData.referrerPageviewId = referrerData.referrerPageviewId;
-                    _addAcquisitionDataToLinks(acquisitionData);
+                    var updatedAcquisitionData = _buildAcquisitionData(acquisitionData, referrerData);
+                    if (updatedAcquisitionData) {
+                        _addAcquisitionDataToLinks(updatedAcquisitionData);
+                    }
                 }
             });
         }

--- a/src/iframeMessenger.js
+++ b/src/iframeMessenger.js
@@ -427,10 +427,10 @@
             var links = document.getElementsByClassName('js-acquisition-link');
             var json = encodeURIComponent(JSON.stringify(acquisitionData));
             for (var i = 0; i < links.length; i++) {
-                var href = link.attr('href');
+                var href = link.getAttribute('href');
                 if (href) {
                     href = `${href}${href.includes('?') ? '&' : '?'}${json}`;
-                    link.attr('href', href);                    
+                    link.setAttribute('href', href);                    
                 }
             }
         }

--- a/src/iframeMessenger.js
+++ b/src/iframeMessenger.js
@@ -423,6 +423,35 @@
             }
         }
 
+        function _addAcquisitionDataToLinks(acquisitionData) {
+            var links = document.getElementsByClassName('js-acquisition-link');
+            var json = JSON.stringify(acquisitionData);
+            for (var i = 0; i < links.length; i++) {
+                var href = link.attr('href');
+                if (href) {
+                    var url;
+                    try {
+                        url = new URL(href);
+                    } catch (e) {
+                        return;
+                    }
+                    url.searchParams.set('acquisitionData', json);
+                    link.attr('href', url.toString())
+                }
+            }
+        }
+
+        function _enrichAcquisitionLinks(acquisitionData) {
+            _addAcquisitionDataToLinks(acquisitionData);
+            var message = { type: 'enrich-acquisition-links' };
+            _postMessage(message, function(data) {
+                var referrerData = data.referrerData;
+                if (referrerData && data.type === message.type) {
+                    _addAcquisitionDataToLinks(Object.assign({}, acquisitionData, referrerData))
+                }
+            });
+        }
+
         // Only setup the page if inside an iframe
         if (_inIframe()) {
             _onLoad(_setupPage);
@@ -437,7 +466,8 @@
             getLocation: getLocation,
             getAbsoluteHeight: _getAbsoluteHeight,
             getPositionInformation: getPositionInformation,
-            monitorPosition: monitorPosition
+            monitorPosition: monitorPosition,
+            enrichAcquisitionLinks: _enrichAcquisitionLinks
         };
     }());
 

--- a/src/iframeMessenger.js
+++ b/src/iframeMessenger.js
@@ -429,7 +429,13 @@
             for (var i = 0; i < links.length; i++) {
                 var href = link.getAttribute('href');
                 if (href) {
-                    href = `${href}${href.includes('?') ? '&' : '?'}${json}`;
+                    if (href.indexOf('?') === -1) {
+                        href += '?';
+                    } else {
+                        href += '&';
+                    }
+                    href += 'acquisitionData=';
+                    href += json;
                     link.setAttribute('href', href);                    
                 }
             }

--- a/src/iframeMessenger.js
+++ b/src/iframeMessenger.js
@@ -425,7 +425,7 @@
 
         function _addAcquisitionDataToLinks(acquisitionData) {
             var links = document.getElementsByClassName('js-acquisition-link');
-            var json = JSON.stringify(acquisitionData);
+            var json = encodeURIComponent(JSON.stringify(acquisitionData));
             for (var i = 0; i < links.length; i++) {
                 var href = link.attr('href');
                 if (href) {


### PR DESCRIPTION
cc @guardian/contributions 

Enriches links on the page with class `"js-acquisition-link"`. An initial enrichment step is taken using the static data provided to `iframeMessenger.enrichAcquisitionLinks()`; and a second enrichment step is taken if the parent window provides referrer data. 

See [#18174](https://github.com/guardian/frontend/pull/18174/files) for the corresponding pull request in frontend.