### PR TITLE
remove initial link enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ _Guardian specific._ Adds the field-value pair `acquisitionData=<encode JSON>` t
 
 ## Changelog
 
+0.2.10
+- Fix bug in acquisition link tracking.
+
 0.2.9
 - Fix bug in acquisition link tracking.
 

--- a/src/iframeMessenger.js
+++ b/src/iframeMessenger.js
@@ -454,7 +454,6 @@
         }
 
         function _enrichAcquisitionLinks(acquisitionData) {
-            _addAcquisitionDataToLinks(acquisitionData);
             var message = { type: 'enrich-acquisition-links' };
             _postMessage(message, function(data) {
                 var referrerData = data.referrerData;

--- a/src/iframeMessenger.js
+++ b/src/iframeMessenger.js
@@ -1,7 +1,7 @@
 /**
  * iframe-messenger
  *
- * version: 0.2.9
+ * version: 0.2.10
  * source: https://github.com/GuardianInteractive/iframe-messenger
  *
  */


### PR DESCRIPTION
In the original pull request, I was adding the `acquisitionData` key to the query string using the `URL()` function. This meant enriching the link multiple times - an initial enrichment, and a complete enrichment once referrer data had been passed from the parent - was ok, because the value of the key would just get overwritten.

However, now the enrichment is being implemented using string concatenation, enriching the link multiple times results in the query string containing multiple `acquisitionData` keys. Since I have verified the secondary link enrichment communication between the iframe and the parent is working, as a quick fix, I am just removing the initial link enrichment step. 

If this pull request is approved, I'll deploy to the `0.2.9` uri, but purge the cache so the updated asset is getting served to all clients immediately.